### PR TITLE
Positioning change in caption.js and progressbar.js

### DIFF
--- a/ui/caption.js
+++ b/ui/caption.js
@@ -166,7 +166,9 @@ X.caption.prototype.init_ = function() {
 
   // enable relative positioning for the main container
   // this is required to place the progressBar in the center
-  this._parent.style.position = 'relative';
+
+  if(this._parent.style.position == 'static' || this._parent.style.position == '')//only do this if the position style is static; this is the only time this hack is needed
+      this._parent.style.position = 'relative';
   
   //
   // apply CSS styles to the document

--- a/ui/progressbar.js
+++ b/ui/progressbar.js
@@ -147,7 +147,9 @@ X.progressbar.prototype.init_ = function() {
 
   // enable relative positioning for the main container
   // this is required to place the progressBar in the center
-  this._parent.style.position = 'relative';
+
+  if(this._parent.style.position == 'static' || this._parent.style.position == '')//only do this if the position style is static; this is the only time this hack is needed
+      this._parent.style.position = 'relative';
   
   //
   // apply CSS styles to the document


### PR DESCRIPTION
This is a small change.

The previous code changed the div containing the renderer canvas to have relative positioning. This allowed the absolute positioning of captions and progressbars to be taken relative to the canvas div rather than the main window.

However, placing any positioning other than the default "static" on the canvas div will work.

In my Neuroview web-app, I was using absolute positioning on my canvas div because I was arranging several of them in a grid.

However, as soon as a progressbar or caption was initialized, XTK would change my canvas div to have relative positioning, destroying my layout.

My change to the XTK code will change the canvas div's positioning to "relative" ONLY if the canvas div's positioning was previously the default "static".

This code has been tested, and the captions and progress bars still work like before.

Thanks,
Mark
