### PR TITLE
Update objects/object.js

### DIFF
--- a/objects/object.js
+++ b/objects/object.js
@@ -210,6 +210,24 @@ X.object.prototype.__defineGetter__('scalars', function() {
 
 
 /**
+ * The transform object associated with this object.
+ * 
+ * @return {?X.transform} The scalars.
+ */
+X.object.prototype.__defineGetter__('transform', function() {
+
+  if (!this._transform) {
+    
+    this._transform = new X.transform();
+    
+  }
+  
+  return this._transform;
+  
+});
+
+
+/**
  * Get the children of this object. Each object can have N children which get
  * automatically rendered when the top level object gets rendered.
  * 


### PR DESCRIPTION
Adding a getter for X.object._transform, so it is possible to change an object transform from outside the framework. Possible uses would be : visualization of medical scenes with surgical stuff, the mesurement with moving a cursor, ...
