### PR TITLE
Update master

### DIFF
--- a/io/loader.js
+++ b/io/loader.js
@@ -299,6 +299,9 @@ X.loader.prototype.complete = function(event) {
     var container = event._container;
     var object = event._object;
     
+    // mark the container as dirty untill the renderer treats it
+    container._dirty = true;
+    
     // mark the container's file as clean
     container._file._dirty = false;
     


### PR DESCRIPTION
According to see issue met here by p0rter (http://stackoverflow.com/questions/11085150/apply-new-layer-to-a-slice-of-a-volume-webgl/) and the tests done on jsFiddle, it seems than somewhere is missing a "object._dirty=true" when object._file is loaded. Indeed the renderer3D well loads new files, but doesn't apply change in buffers (for example for textures).
