### PR TITLE
update parseNII to deal with .gz files with file length not multiple of 4 bytes

### DIFF
--- a/io/parserNII.js
+++ b/io/parserNII.js
@@ -74,9 +74,12 @@ X.parserNII.prototype.parse = function(container, object, data, flag) {
   
   var _data = data;
   
-  // check if this data is compressed, then this int != 348
-  var _compressionCheck = new Uint32Array(data, 0, 1)[0];
   
+  // check if this data is compressed, then this int != 348
+  //var _compressionCheck = new Int32Array(data,0,1)[0];
+  var dataview = new DataView(data, 0);
+  var _compressionCheck = dataview.getInt32(0,littleEndian=true);
+
   if (_compressionCheck != 348) {
     
     // we need to decompress the datastream


### PR DESCRIPTION
in Safari, parseNII was not accepting gziped nii files whose file length was not a multiple of 4bytes. Using DataView instead of Uint32Array solved the issue.
