### PR TITLE
Added complex and double data types to parser and parserNII

### DIFF
--- a/io/parser.js
+++ b/io/parser.js
@@ -278,6 +278,14 @@ X.parser.prototype.scan = function(type, chunks) {
     _array_type = Float32Array;
     _chunkSize = 4;
     break;
+  case 'complex':
+    _array_type = Float64Array;
+    _chunkSize = 8;
+    break;
+  case 'double':
+    _array_type = Float64Array;
+    _chunkSize = 8;
+    break;
 
   }
 

--- a/io/parserNII.js
+++ b/io/parserNII.js
@@ -307,6 +307,14 @@ X.parserNII.prototype.parseStream = function(data) {
     // float
     MRI.data = this.scan('float', volsize);
     break;
+  case 32:
+    // complex
+    MRI.data = this.scan('complex', volsize);
+    break;
+  case 64:
+    // double
+    MRI.data = this.scan('double', volsize);
+    break;
   case 256:
     // signed char
     MRI.data = this.scan('schar', volsize);


### PR DESCRIPTION
parser.js doesn't support parsing of 8-bit data types at the moment, producing errors when trying to load some .nii images from file. I've added handling of complex and double NIfTI volumes.
