### PR TITLE
Fixes alignment of DICOM data due to failure to round

### DIFF
--- a/io/parserDCM.js
+++ b/io/parserDCM.js
@@ -359,7 +359,7 @@ X.parserDCM.prototype.parse = function(container, object, data, flag) {
           break;
       }
 
-      first_image_data.set(_data, _distance_position * first_slice_size);
+      first_image_data.set(_data, Math.round(_distance_position) * first_slice_size);
 
     }
 


### PR DESCRIPTION
We should offset into data by integer multiple of the slice size, but `_distance_position` can be a non-integer
due to arithmetic precision in the calculation when ordering by `image_position_patient`. This led to misaligned volume slices. The simple fix ensures we multiply the slice size by an integer.
