### PR TITLE
Exposing 'resize' function on renderers

### DIFF
--- a/visualization/renderer.js
+++ b/visualization/renderer.js
@@ -406,6 +406,14 @@ X.renderer.prototype.onHover_ = function(event) {
  * @protected
  */
 X.renderer.prototype.onResize_ = function() {
+    this.resize();
+};
+
+
+/**
+ * Resizes the control to fit the size of the container.
+ */
+X.renderer.prototype.resize = function() {
 
   // grab the new width and height of the container
   var container = goog.dom.getElement(this._container);

--- a/visualization/renderer2D.js
+++ b/visualization/renderer2D.js
@@ -1380,3 +1380,4 @@ goog.exportSymbol('X.renderer2D.prototype.destroy',
 goog.exportSymbol('X.renderer2D.prototype.onSliceNavigation', X.renderer2D.prototype.onSliceNavigation);
 
 goog.exportSymbol('X.renderer2D.prototype.afterRender', X.renderer2D.prototype.afterRender);
+goog.exportSymbol('X.renderer2D.prototype.resize', X.renderer2D.prototype.resize);

--- a/visualization/renderer3D.js
+++ b/visualization/renderer3D.js
@@ -2416,3 +2416,4 @@ goog.exportSymbol('X.renderer3D.prototype.resetViewAndRender',
 goog.exportSymbol('X.renderer3D.prototype.pick', X.renderer3D.prototype.pick);
 goog.exportSymbol('X.renderer3D.prototype.pick3d', X.renderer3D.prototype.pick3d);
 goog.exportSymbol('X.renderer3D.prototype.afterRender', X.renderer3D.prototype.afterRender);
+goog.exportSymbol('X.renderer3D.prototype.resize', X.renderer3D.prototype.resize);


### PR DESCRIPTION
The existing X.renderer.onResize_ function is only called when the window resizes.  If the container is a different element, there was no way to trigger a resize.

This commit adds a X.renderer.resize() function.  It does the exact same thing as onResize_(), except that it is now publicly accessible and exported.