### PR TITLE
Consider labelmap opacity when rendering it on 2D canvas

### DIFF
--- a/visualization/renderer2D.js
+++ b/visualization/renderer2D.js
@@ -1274,7 +1274,7 @@ X.renderer2D.prototype.render_ = function(picking, invoked) {
   // draw the labels with a configured opacity
   if (_currentLabelMap && _volume._labelmap._visible) {
 
-    var _labelOpacity = 1;//_volume._labelmap._opacity;
+    var _labelOpacity = _volume._labelmap._opacity;
     this._context.globalAlpha = _labelOpacity; // draw transparent depending on
     // opacity
     this._context.drawImage(this._labelFrameBuffer, _offset_x, _offset_y,


### PR DESCRIPTION
For some reason labelmap opacity is considered for 3D rendering, but not considered for 2D rendering. It was commented out a while ago. I propose to return it back