### PR TITLE
Update closure-library submodule URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "lib/google-closure-library"]
 	path = lib/google-closure-library
-	url = https://code.google.com/p/closure-library/
+	url = https://github.com/google/closure-library


### PR DESCRIPTION
code.google.com no longer works, so `git submodule update` fails.