### PR TITLE
[Fix] Raw encoded NRRDs parse correctly

### DIFF
--- a/io/parserNRRD.js
+++ b/io/parserNRRD.js
@@ -93,9 +93,15 @@ X.parserNRRD.prototype.parse = function(container, object, data, flag) {
     // here we start the unzipping and get a typed Uint8Array back
     var inflate = new Zlib.Gunzip(new Uint8Array(_data));
     _data = inflate.decompress();
+    // .. let's use the underlying array buffer
+    _data = _data.buffer;
   }
-  // .. let's use the underlying array buffer
-  _data = _data.buffer;
+  else
+  {
+    // If the data is raw, get the array buffer of only the data.
+    _data = _data.buffer.slice(_data_start);
+  }
+
   var MRI = {
     data : null,
     min : Infinity,


### PR DESCRIPTION
The original code used an ArrayBuffer to get the voxel data, this worked fine for gzip/gz encoded files because when the voxel data was decompressed, it returned a new ArrayBuffer of just the voxel data, so just using `_data = _data.buffer;` worked fine.

When a raw file was detected, it also grabbed the ArrayBuffer of the sliced data, but, it turns that this variable is a subarray of the whole file as seen in `var _data = _bytes.subarray(_data_start);`. 

Problem is, trying to get the buffer from a sliced subarray returns the whole original buffer, not a sliced one; so this was fixed by using the same offset to only get the buffer data of the voxels like so: `    _data = _data.buffer.slice(_data_start);`
